### PR TITLE
ci: drop eol emacs versions failing on modern transient dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,10 @@ jobs:
       fail-fast: false
       matrix:
         emacs_version:
-          - '26.1'
-          - '26.2'
-          - '26.3'
-          - '27.1'
+          - '28.1'
+          - '28.2'
+          - '29.4'
+          - '30.1'
           - 'snapshot'
         include:
           - emacs_version: 'snapshot'

--- a/transient-dwim.el
+++ b/transient-dwim.el
@@ -5,7 +5,7 @@
 ;; Author: Naoya Yamashita <conao3@gmail.com>
 ;; Version: 1.0.9
 ;; Keywords: tools
-;; Package-Requires: ((emacs "26.1") (transient "0.1"))
+;; Package-Requires: ((emacs "28.1") (transient "0.1"))
 ;; URL: https://github.com/conao3/transient-dwim.el
 
 ;; This program is free software: you can redistribute it and/or modify


### PR DESCRIPTION
## Root cause

The latest `Main workflow` run on `master` (run 25565592389, "Update GitHub Actions versions") failed: all four pinned matrix jobs `build (26.1)`, `(26.2)`, `(26.3)`, `(27.1)` exited with code 2, while `build (snapshot)` passed.

This is EOL-Emacs matrix rot, not a code bug. The MELPA `transient` package now declares:

```
Package-Requires: ((emacs "28.1") (compat "31.0") (cond-let "1.1") (seq "2.24"))
```

and `cond-let` itself requires `(emacs "28.1")`. On Emacs 26.1–27.1 the dependency chain no longer byte-compiles, so `make build`/`make test` fails with exit code 2. Modern Emacs (`snapshot`) is unaffected — the package's own source compiles and the buttercup spec passes (verified locally on Emacs 29.3).

## Fix

- Replace the EOL Emacs matrix (`26.1`/`26.2`/`26.3`/`27.1`) with currently supported releases (`28.1`/`28.2`/`29.4`/`30.1`), keeping `snapshot`.
- Bump the package header to `((emacs "28.1") (transient "0.1"))` so `Package-Requires` stays consistent with the actual minimum Emacs the transient dependency now imposes.

No source/test/lint changes were needed — the code is correct.

## Test plan

- [x] `make build` succeeds locally (Emacs 29.3)
- [x] `make test` succeeds locally (1 spec, 0 failed)
- [ ] CI green on the new matrix (28.1 / 28.2 / 29.4 / 30.1 / snapshot)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Eo1Cb6K6AkErpgjBJZMixd)_