### PR TITLE
chore: bump transient dependency to 0.13.3

### DIFF
--- a/transient-dwim.el
+++ b/transient-dwim.el
@@ -5,7 +5,7 @@
 ;; Author: Naoya Yamashita <conao3@gmail.com>
 ;; Version: 1.0.9
 ;; Keywords: tools
-;; Package-Requires: ((emacs "28.1") (transient "0.1"))
+;; Package-Requires: ((emacs "28.1") (transient "0.13.3"))
 ;; URL: https://github.com/conao3/transient-dwim.el
 
 ;; This program is free software: you can redistribute it and/or modify


### PR DESCRIPTION
## Summary

Modernizes the package dependencies to their latest versions.

- Bumped the `transient` requirement in `Package-Requires` from `0.1` to `0.13.3` (latest on GNU ELPA). The codebase already uses modern transient definition macro names, so this aligns the declared minimum with what the code actually relies on.

### Notes on other dependencies

- `buttercup` (dev dependency in `Cask`) is unpinned and always resolves to the latest from MELPA — nothing to update.
- CI GitHub Actions (`actions/checkout@v6`, `actions/setup-python@v6`, `purcell/setup-emacs@master`, `conao3/setup-cask@master`) are already current.
- Cask projects have no lockfile, so there is nothing to regenerate.
- No major upgrades had to be deferred.

## Test plan

- [x] `cask install` resolves `transient 0.13.3`
- [x] `make test` (byte-compile + buttercup) passes green; only pre-existing optional-`magit` byte-compile warnings remain, unchanged from baseline


---
_Generated by [Claude Code](https://claude.ai/code/session_01LXALZu1zim4QXYGMMwSFVH)_